### PR TITLE
Add summarization fallback for long TTS replies

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -868,8 +868,10 @@ class TTSRequest(BaseModel):
         if len(v.strip()) == 0:
             raise ValueError('Text cannot be empty')
 
-        if len(v) > 4096:
-            raise ValueError('Text is too long (max 4096 characters)')
+        # This is just an abuse guardrail, not the TTS limit. Text longer than
+        # OpenAI's 4096-char TTS limit is summarized down to size in the endpoint.
+        if len(v) > 50000:
+            raise ValueError('Text is too long (max 50000 characters)')
 
         return v.strip()
 
@@ -1440,15 +1442,32 @@ async def get_app_config(request: Request):
         max_image_size_mb=MAX_IMAGE_SIZE_MB
     )
 
+def _truncate_at_boundary(text: str, max_len: int) -> str:
+    """Truncate text to at most max_len characters, breaking at a sentence or word boundary."""
+    if len(text) <= max_len:
+        return text
+
+    truncated = text[:max_len]
+
+    last_sentence_end = max(truncated.rfind('.'), truncated.rfind('!'), truncated.rfind('?'))
+    if last_sentence_end > max_len * 0.5:
+        return truncated[:last_sentence_end + 1].strip()
+
+    last_space = truncated.rfind(' ')
+    if last_space > 0:
+        return truncated[:last_space].strip()
+
+    return truncated.strip()
+
 # Endpoint for text-to-speech
 @app.post(
     "/api/tts",
     tags=["Audio"],
     summary="Convert text to speech",
-    description="Convert text to speech using OpenAI's TTS API. Returns MP3 audio data. Requires an OpenAI API key (user-provided via X-API-Key header, stored in session, or server-configured). Works regardless of the session's selected provider.",
+    description="Convert text to speech using OpenAI's TTS API. Returns MP3 audio data. Text longer than OpenAI's 4096-character TTS limit is automatically summarized (with the X-TTS-Summarized response header set to true) before being sent to TTS. Requires an OpenAI API key (user-provided via X-API-Key header, stored in session, or server-configured). Works regardless of the session's selected provider.",
     responses={
         200: {"description": "Audio generated successfully", "content": {"audio/mpeg": {}}},
-        400: {"description": "Invalid request (empty text or exceeds 4096 characters)"},
+        400: {"description": "Invalid request (empty text or exceeds 50000 characters)"},
         401: {"description": "Invalid or expired session"},
         403: {"description": "No OpenAI API key available. Provide one via X-API-Key header or configure a server key."},
         429: {"description": "Rate limit exceeded"},
@@ -1488,11 +1507,45 @@ async def text_to_speech(
         from openai_helper import create_openai_client
         client = create_openai_client(api_key, "openai")
 
+        TTS_CHAR_LIMIT = 4096
+        tts_text = tts_request.text
+        summarized = False
+
+        if len(tts_text) > TTS_CHAR_LIMIT:
+            try:
+                summary_response = client.chat.completions.create(
+                    model="gpt-5-mini",
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": (
+                                "You summarize text for spoken narration. Produce a concise, "
+                                "natural-sounding spoken-style summary that preserves the key "
+                                "points and tone of the original text. Keep the summary under "
+                                "3000 characters."
+                            )
+                        },
+                        {
+                            "role": "user",
+                            "content": tts_text
+                        }
+                    ],
+                    temperature=0.5,
+                    max_tokens=1500
+                )
+                summary_text = summary_response.choices[0].message.content.strip()
+                tts_text = _truncate_at_boundary(summary_text, TTS_CHAR_LIMIT)
+                summarized = True
+            except Exception:
+                logger.exception("Error summarizing long text for TTS, falling back to truncation")
+                tts_text = _truncate_at_boundary(tts_text, TTS_CHAR_LIMIT)
+                summarized = True
+
         # Call OpenAI TTS API
         response = client.audio.speech.create(
             model="gpt-4o-mini-tts",
             voice=tts_request.voice,
-            input=tts_request.text,
+            input=tts_text,
             response_format="mp3"
         )
 
@@ -1501,7 +1554,11 @@ async def text_to_speech(
 
         # Return binary MP3 response
         from fastapi.responses import Response
-        return Response(content=audio_bytes, media_type="audio/mpeg")
+        return Response(
+            content=audio_bytes,
+            media_type="audio/mpeg",
+            headers={"X-TTS-Summarized": "true" if summarized else "false"}
+        )
 
     except HTTPException:
         raise

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -155,7 +155,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -538,7 +537,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -579,7 +577,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1739,7 +1736,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1876,7 +1874,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1888,7 +1885,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1948,7 +1944,6 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2222,7 +2217,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2417,7 +2411,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001735",
         "electron-to-chromium": "^1.5.204",
@@ -2861,7 +2854,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3023,7 +3017,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4397,6 +4390,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5663,6 +5657,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5678,6 +5673,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5737,7 +5733,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5750,7 +5745,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5764,7 +5758,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -6352,7 +6347,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6511,7 +6505,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6734,7 +6727,6 @@
       "integrity": "sha512-+v57oAaoYNnO3hIu5Z/tJRZjq5aHM2zDve9YZ8HngVHbhk66RStobhb1sqPMIPEleV6cNKYK4eGrAbE9Ulbl2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -7330,7 +7322,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7389,7 +7380,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/frontend/src/components/ChatInterface.css
+++ b/frontend/src/components/ChatInterface.css
@@ -1232,6 +1232,49 @@
   animation: spin 1s linear infinite;
 }
 
+.tts-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  margin-top: 6px;
+  width: fit-content;
+  max-width: 100%;
+  animation: slideDown 0.2s ease-out;
+}
+
+.tts-notice-summarized {
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: var(--accent-primary);
+}
+
+.tts-notice-error {
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: var(--accent-error);
+}
+
+.tts-notice-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0.125rem;
+  border-radius: 0.25rem;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.tts-notice-dismiss:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
 .message-timestamp {
   font-size: 0.6875rem;
   color: var(--text-muted);

--- a/frontend/src/components/ChatInterface.tsx
+++ b/frontend/src/components/ChatInterface.tsx
@@ -244,9 +244,11 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
   // TTS state
   const [playingMessageId, setPlayingMessageId] = useState<string | null>(null)
   const [loadingTtsId, setLoadingTtsId] = useState<string | null>(null)
+  const [ttsNotice, setTtsNotice] = useState<{ messageId: string; type: 'summarized' | 'error'; text: string } | null>(null)
   const audioRef = useRef<HTMLAudioElement | null>(null)
   const audioBlobUrlRef = useRef<string | null>(null)
   const ttsAbortControllerRef = useRef<AbortController | null>(null)
+  const ttsNoticeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Dictate state
   const [isRecording, setIsRecording] = useState(false)
@@ -529,6 +531,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
         URL.revokeObjectURL(audioBlobUrlRef.current)
         audioBlobUrlRef.current = null
       }
+      if (ttsNoticeTimerRef.current) {
+        clearTimeout(ttsNoticeTimerRef.current)
+        ttsNoticeTimerRef.current = null
+      }
     }
   }, [])
 
@@ -776,6 +782,25 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
     }
   }
 
+  const showTtsNotice = (messageId: string, type: 'summarized' | 'error', text: string) => {
+    if (ttsNoticeTimerRef.current) {
+      clearTimeout(ttsNoticeTimerRef.current)
+    }
+    setTtsNotice({ messageId, type, text })
+    ttsNoticeTimerRef.current = setTimeout(() => {
+      setTtsNotice(null)
+      ttsNoticeTimerRef.current = null
+    }, 6000)
+  }
+
+  const dismissTtsNotice = () => {
+    if (ttsNoticeTimerRef.current) {
+      clearTimeout(ttsNoticeTimerRef.current)
+      ttsNoticeTimerRef.current = null
+    }
+    setTtsNotice(null)
+  }
+
   const handleReadAloud = async (message: Message) => {
     // Toggle off if already playing this message
     if (playingMessageId === message.id) {
@@ -789,6 +814,8 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
       }
       return
     }
+
+    dismissTtsNotice()
 
     // Abort any in-flight TTS request to prevent race conditions
     if (ttsAbortControllerRef.current) {
@@ -839,6 +866,10 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
         throw new Error(`TTS request failed: ${response.status}`)
       }
 
+      if (response.headers.get('X-TTS-Summarized') === 'true') {
+        showTtsNotice(message.id, 'summarized', 'Playing a summarized version — the full response was too long for audio')
+      }
+
       const blob = await response.blob()
 
       const url = URL.createObjectURL(blob)
@@ -887,7 +918,7 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
       }
       console.error('TTS error:', error)
       setLoadingTtsId(null)
-      // Could show error message to user here if needed
+      showTtsNotice(message.id, 'error', "Couldn't play audio for this message. Try again.")
     }
   }
 
@@ -1829,6 +1860,19 @@ const ChatInterface: React.FC<ChatInterfaceProps> = ({
                           ) : (
                             <Volume2 size={14} />
                           )}
+                        </button>
+                      </div>
+                    )}
+
+                    {ttsNotice && ttsNotice.messageId === message.id && (
+                      <div className={`tts-notice tts-notice-${ttsNotice.type}`} role="status">
+                        <span>{ttsNotice.text}</span>
+                        <button
+                          className="tts-notice-dismiss"
+                          onClick={dismissTtsNotice}
+                          aria-label="Dismiss notice"
+                        >
+                          <X size={12} />
                         </button>
                       </div>
                     )}

--- a/frontend/src/components/ChatInterface.tts.test.tsx
+++ b/frontend/src/components/ChatInterface.tts.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ChatInterface from './ChatInterface'
+
+// Mock lucide-react icons
+vi.mock('lucide-react', () => ({
+  Send: () => <div>Send</div>,
+  MessageSquare: () => <div>MessageSquare</div>,
+  User: () => <div>User</div>,
+  Bot: () => <div>Bot</div>,
+  Trash2: () => <div>Trash2</div>,
+  Settings: () => <div>Settings</div>,
+  ArrowDown: () => <div>ArrowDown</div>,
+  X: () => <div>X</div>,
+  FileText: () => <div>FileText</div>,
+  Upload: () => <div>Upload</div>,
+  Compass: () => <div>Compass</div>,
+  Image: () => <div>Image</div>,
+  Plus: () => <div>Plus</div>,
+  Search: () => <div>Search</div>,
+  BookOpen: () => <div>BookOpen</div>,
+  Brain: () => <div>Brain</div>,
+  Volume2: () => <div>Volume2</div>,
+  Square: () => <div>Square</div>,
+  Mic: () => <div>Mic</div>,
+  MicOff: () => <div>MicOff</div>,
+}))
+
+// Mock MarkdownRenderer
+vi.mock('./MarkdownRenderer', () => ({
+  default: ({ content }: { content: string }) => <div>{content}</div>,
+}))
+
+// Mock SuggestedQuestions
+vi.mock('./SuggestedQuestions', () => ({
+  default: () => <div>SuggestedQuestions</div>,
+}))
+
+// Mock SettingsModal
+vi.mock('./SettingsModal', () => ({
+  default: () => <div>SettingsModal</div>,
+}))
+
+class MockAudio {
+  onended: (() => void) | null = null
+  onerror: (() => void) | null = null
+  play = vi.fn().mockResolvedValue(undefined)
+  pause = vi.fn()
+  constructor(public src?: string) {}
+}
+
+describe('ChatInterface - TTS summarized notice and error surfacing', () => {
+  const originalFetch = global.fetch
+  const originalAudio = global.Audio
+  const originalCreateObjectURL = URL.createObjectURL
+  const originalRevokeObjectURL = URL.revokeObjectURL
+
+  const defaultProps = {
+    apiKey: 'test-key',
+    setApiKey: vi.fn(),
+    sessionId: 'test-session',
+    selectedModel: 'gpt-5-mini',
+    setSelectedModel: vi.fn(),
+    selectedProvider: 'openai',
+    setSelectedProvider: vi.fn(),
+    modelDescriptions: {},
+    sidebarOpen: false,
+    settingsModalOpen: false,
+    setSettingsModalOpen: vi.fn(),
+    isWhitelisted: true,
+    freeTurnsRemaining: 10,
+    authType: 'guest' as const,
+    onFreeTurnsUpdate: vi.fn(),
+    hasFreeTurns: true,
+    hasOwnApiKey: true,
+    welcomeSuggestions: [],
+    maxImageSizeMB: 3,
+    setStudyLearnOverride: vi.fn(),
+    ttsVoice: 'marin',
+    setTtsVoice: vi.fn(),
+  }
+
+  // Sends a message and waits for the assistant response so the
+  // "Read aloud" button becomes available for that message.
+  const sendMessageAndGetReadAloudButton = async () => {
+    render(<ChatInterface {...defaultProps} />)
+
+    const textarea = screen.getByRole('textbox')
+    fireEvent.change(textarea, { target: { value: 'Hello there' } })
+    const form = textarea.closest('form')!
+    fireEvent.submit(form)
+
+    await waitFor(() => {
+      expect(screen.getByText('Test response')).toBeInTheDocument()
+    })
+
+    return screen.getByTitle('Read aloud')
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    global.Audio = MockAudio as unknown as typeof Audio
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url')
+    URL.revokeObjectURL = vi.fn()
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    global.Audio = originalAudio
+    URL.createObjectURL = originalCreateObjectURL
+    URL.revokeObjectURL = originalRevokeObjectURL
+  })
+
+  const mockChatAndConversationsFetch = (ttsHandler: (url: string) => Promise<Response>) => {
+    global.fetch = vi.fn((url) => {
+      if (url === '/api/conversations') {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response)
+      }
+      if (url === '/api/tts') {
+        return ttsHandler(url as string)
+      }
+      return Promise.resolve({
+        ok: true,
+        headers: new Headers({
+          'X-Conversation-ID': 'test-conv-123',
+          'X-Free-Turns-Remaining': '9',
+        }),
+        body: {
+          getReader: () => ({
+            read: vi.fn()
+              .mockResolvedValueOnce({ done: false, value: new TextEncoder().encode('Test response') })
+              .mockResolvedValueOnce({ done: true, value: undefined }),
+          }),
+        },
+      } as any)
+    })
+  }
+
+  it('shows a summarized notice when the TTS response includes the X-TTS-Summarized header', async () => {
+    mockChatAndConversationsFetch(() =>
+      Promise.resolve({
+        ok: true,
+        headers: new Headers({ 'X-TTS-Summarized': 'true' }),
+        blob: () => Promise.resolve(new Blob(['audio'], { type: 'audio/mpeg' })),
+      } as unknown as Response)
+    )
+
+    const readAloudButton = await sendMessageAndGetReadAloudButton()
+    fireEvent.click(readAloudButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Playing a summarized version/i)).toBeInTheDocument()
+    })
+  })
+
+  it('shows no notice when the X-TTS-Summarized header is absent', async () => {
+    mockChatAndConversationsFetch(() =>
+      Promise.resolve({
+        ok: true,
+        headers: new Headers(),
+        blob: () => Promise.resolve(new Blob(['audio'], { type: 'audio/mpeg' })),
+      } as unknown as Response)
+    )
+
+    const readAloudButton = await sendMessageAndGetReadAloudButton()
+    fireEvent.click(readAloudButton)
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/tts', expect.any(Object))
+    })
+
+    expect(screen.queryByText(/Playing a summarized version/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Couldn't play audio/i)).not.toBeInTheDocument()
+  })
+
+  it('shows an error notice when the TTS fetch fails, instead of failing silently', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mockChatAndConversationsFetch(() => Promise.reject(new Error('network down')))
+
+    const readAloudButton = await sendMessageAndGetReadAloudButton()
+    fireEvent.click(readAloudButton)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't play audio for this message/i)).toBeInTheDocument()
+    })
+
+    consoleErrorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- Backend (`api/app.py`): the `/api/tts` endpoint previously rejected text over 4096 chars (OpenAI TTS's hard limit) with a 422, causing the "read aloud" button to silently fail on long replies. Now it summarizes long text via `gpt-5-mini` (with boundary-safe truncation as a safety net), flags the response with an `X-TTS-Summarized` header, and falls back to truncation if summarization itself fails.
- Frontend (`ChatInterface.tsx`/`.css`): `handleReadAloud` now detects the `X-TTS-Summarized` header and shows a dismissible "playing a summarized version" notice, and surfaces a generic error notice on any TTS failure instead of failing silently (previously only logged to console).

## Test plan
- [x] `cd api && python -m py_compile app.py` passes
- [x] `cd frontend && npx vitest run src/components/ChatInterface.tts.test.tsx` — 3/3 pass
- [x] `cd frontend && npx tsc --noEmit` — no type errors
- [ ] Manually click "read aloud" on a long AI response and confirm the summarized-version notice appears with audio playback
- [ ] Manually trigger a TTS failure (e.g. remove API key) and confirm the visible error notice appears instead of silent failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)